### PR TITLE
Vectorize block_diag to avoid inner loops over block elements

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -192,10 +192,10 @@ class Construction(Benchmark):
             T[i, j] = v
 
 
-class BlockDiagConstruction(Benchmark):
+class BlockDiagDenseConstruction(Benchmark):
     param_names = ['num_matrices']
     params = [1000, 5000, 10000, 15000, 20000]
-    
+
     def setup(self, num_matrices):
         self.matrices = []
         for i in range(num_matrices):
@@ -203,9 +203,25 @@ class BlockDiagConstruction(Benchmark):
             columns = np.random.randint(1, 4)
             mat = np.random.randint(0, 10, (rows, columns))
             self.matrices.append(mat)
-            
+
     def time_block_diag(self, num_matrices):
-        sparse.block_diag(self.matrices)            
+        sparse.block_diag(self.matrices)
+
+
+class BlockDiagSparseConstruction(Benchmark):
+    param_names = ['num_matrices']
+    params = [100, 500, 1000, 1500, 2000]
+
+    def setup(self, num_matrices):
+        self.matrices = []
+        for i in range(num_matrices):
+            rows = np.random.randint(1, 20)
+            columns = np.random.randint(1, 20)
+            mat = np.random.randint(0, 10, (rows, columns))
+            self.matrices.append(mat)
+
+    def time_block_diag(self, num_matrices):
+        sparse.block_diag(self.matrices)
 
 
 class Conversion(Benchmark):


### PR DESCRIPTION
This PR modifies block_diag to avoid inner loops over the block entries via vectorization and early conversions to COO.  This results in comparable performance with small dense blocks, but better performance with large dense blocks or sparse blocks.

Before (commit 90cfcbd1291930929736b7c8d182168a456bd8d6):

```
[100.00%] ··· sparse.BlockDiagDenseConstruction.time_block_diag                                       ok
[100.00%] ··· ============== ============
               num_matrices              
              -------------- ------------
                   1000       8.01±0.3ms 
                   5000       37.3±0.9ms 
                  10000        79.3±1ms  
                  15000        122±4ms   
                  20000        164±2ms   
              ============== ============

[100.00%] ··· sparse.BlockDiagSparseConstruction.time_block_diag                                      ok
[100.00%] ··· ============== ==========
               num_matrices            
              -------------- ----------
                   100        13.5±1ms 
                   500        69.5±1ms 
                   1000       150±3ms  
                   1500       221±7ms  
                   2000       296±4ms  
              ============== ==========
```

After (commit bfa3269d108be255aab7420f0be20ee5662155a1):

```
[100.00%] ··· sparse.BlockDiagDenseConstruction.time_block_diag                                       ok
[100.00%] ··· ============== ============
               num_matrices              
              -------------- ------------
                   1000       7.57±0.1ms 
                   5000        38.9±1ms  
                  10000       75.1±0.9ms 
                  15000        115±2ms   
                  20000        158±8ms   
              ============== ============

[100.00%] ··· sparse.BlockDiagSparseConstruction.time_block_diag                                      ok
[100.00%] ··· ============== ============
               num_matrices              
              -------------- ------------
                   100         995±30μs  
                   500        4.98±0.1ms 
                   1000       10.2±0.4ms 
                   1500       15.6±0.9ms 
                   2000       21.2±0.6ms 
              ============== ============
```